### PR TITLE
fix: Resolve GitHub Pages 404 error for stage JSON files

### DIFF
--- a/src/core/StageLoader.ts
+++ b/src/core/StageLoader.ts
@@ -74,7 +74,10 @@ export class StageLoader {
         }
 
         try {
-            const response = await fetch(`/stages/stage${stageId}.json`);
+            // Use Vite's BASE_URL to resolve correct path for both local and production environments
+            const baseUrl = import.meta.env.BASE_URL;
+            const stageUrl = `${baseUrl}stages/stage${stageId}.json`;
+            const response = await fetch(stageUrl);
 
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}`);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- Fixed GitHub Pages 404 error when loading stage JSON files
- Modified `StageLoader.ts` to use `import.meta.env.BASE_URL` for correct path resolution
- Added `vite-env.d.ts` for proper Vite TypeScript support

## Problem
Stage JSON files were returning 404 errors on GitHub Pages deployment due to incorrect path resolution:
- Local development: `fetch('/stages/stage1.json')` → `http://localhost:5173/stages/stage1.json` ✅
- GitHub Pages: `fetch('/stages/stage1.json')` → `https://user.github.io/stages/stage1.json` ❌
- Correct path should be: `https://user.github.io/jumping-dot-game/stages/stage1.json`

## Solution
Used Vite's `import.meta.env.BASE_URL` which automatically resolves to:
- Local development: `/`
- Production deployment: `/jumping-dot-game/`

## Test plan
- [x] TypeScript compilation passes
- [x] Build process succeeds
- [x] All tests pass (453/453)
- [x] Local preview confirmed working (`npm run preview`)
- [ ] GitHub Pages deployment verification

## Files Changed
- `src/core/StageLoader.ts`: Updated JSON fetch path to use BASE_URL
- `src/vite-env.d.ts`: Added Vite TypeScript definitions

Resolves #55

🤖 Generated with [Claude Code](https://claude.ai/code)