### PR TITLE
fix: Reset moving platforms to initial positions on game restart

### DIFF
--- a/src/core/Game.ts
+++ b/src/core/Game.ts
@@ -74,7 +74,7 @@ export class JumpingDotGame {
             await this.gameManager.loadStage(getGameStore().getCurrentStage());
     
             this.gameUI.showReadyToStart();
-            await this.gameManager.resetGameState();
+            await await this.gameManager.resetGameState();
             this.gameUI.updateInitialUI();
     
             // Clear inputs after a short delay
@@ -93,7 +93,7 @@ export class JumpingDotGame {
         await this.gameManager.loadStage(stageId);
 
         this.gameUI.showReadyToStart();
-        this.gameManager.resetGameState();
+        await this.gameManager.resetGameState();
         this.gameUI.updateInitialUI();
 
         // Clear inputs after a short delay

--- a/src/core/Game.ts
+++ b/src/core/Game.ts
@@ -71,10 +71,10 @@ export class JumpingDotGame {
             this.gameLoop.resetCleanupState(); // Reset cleanup flag
             this.gameUI.showLoading();
     
-            await this.gameManager.loadStage(getGameStore().getCurrentStage());
+        await this.gameManager.loadStage(getGameStore().getCurrentStage());
     
             this.gameUI.showReadyToStart();
-            await await this.gameManager.resetGameState();
+            await this.gameManager.resetGameState();
             this.gameUI.updateInitialUI();
     
             // Clear inputs after a short delay

--- a/src/core/GameManager.ts
+++ b/src/core/GameManager.ts
@@ -155,6 +155,10 @@ export class GameManager {
             // Reinitialize all systems with fresh instances
             this.initializeSystems(this.gameController);
     
+            // Reload stage to get clean initial data
+            const currentStageId = this.stage?.id || 1; // Use current stage ID or fallback to 1
+            this.stage = await this.stageLoader.loadStageWithFallback(currentStageId);
+    
             this.playerSystem.reset(100, 400);
             this.animationSystem.reset();
     
@@ -164,6 +168,7 @@ export class GameManager {
             this.inputManager.clearInputs();
             this.prevPlayerY = 0;
         }
+
 
 
 

--- a/src/core/StageLoader.ts
+++ b/src/core/StageLoader.ts
@@ -148,7 +148,8 @@ export class StageLoader {
         // Check cache first
         const cachedStage = this.cache.get(stageId);
         if (cachedStage) {
-            return cachedStage;
+            // Return a deep copy to avoid reference sharing issues
+            return JSON.parse(JSON.stringify(cachedStage));
         }
 
         try {

--- a/src/test/GameManager.test.ts
+++ b/src/test/GameManager.test.ts
@@ -367,7 +367,56 @@ describe('GameManager', () => {
             expect(mockAnimationSystem.updateDeathAnimation).toHaveBeenCalled();
         });
     });
-
+                                     
+                                         describe('resetGameState method', () => {
+                                             it('should reset moving platforms to their initial positions on game restart', async () => {
+                                                 // Arrange: Load a stage with moving platforms
+                                                 const mockStage = {
+                                                     id: 2,
+                                                     name: 'Test Stage with Moving Platforms',
+                                                     platforms: [],
+                                                     spikes: [],
+                                                     goal: { x: 700, y: 450, width: 40, height: 50 },
+                                                     movingPlatforms: [
+                                                         {
+                                                             x1: 200, x2: 250, y1: 400, y2: 400,
+                                                             startX: 200, endX: 300, speed: 2, direction: 1
+                                                         },
+                                                         {
+                                                             x1: 500, x2: 550, y1: 350, y2: 350,
+                                                             startX: 500, endX: 600, speed: 1.5, direction: -1
+                                                         }
+                                                     ]
+                                                 };
+                                                 const mockStageLoader = (gameManager as any).stageLoader;
+                                                 // Return a deep copy each time to avoid reference sharing
+                                                 mockStageLoader.loadStageWithFallback = vi.fn().mockImplementation(() => 
+                                                     Promise.resolve(JSON.parse(JSON.stringify(mockStage)))
+                                                 );
+                                     
+                                                 await gameManager.loadStage(2);
+                                                 gameManager.startGame();
+                                     
+                                                 // Store initial platform positions
+                                                 const initialPlatforms = JSON.parse(JSON.stringify(gameManager.getCurrentStage()?.movingPlatforms));
+                                     
+                                                 // Act: Simulate time progression to move platforms
+                                                 for (let i = 0; i < 10; i++) {
+                                                     gameManager.update(16.67);
+                                                 }
+                                     
+                                                 // Verify platforms have moved from initial positions
+                                                 const movedPlatforms = gameManager.getCurrentStage()?.movingPlatforms;
+                                                 expect(movedPlatforms?.[0].x1).not.toBe(initialPlatforms[0].x1);
+                                     
+                                                 // Act: Reset game state
+                                                 await gameManager.resetGameState();
+                                     
+                                                 // Assert: Platforms should be back to initial positions
+                                                 const resetPlatforms = gameManager.getCurrentStage()?.movingPlatforms;
+                                                 expect(resetPlatforms).toEqual(initialPlatforms);
+                                             });
+                                         });
     describe('edge cases and error handling', () => {
         it('should handle missing stage gracefully', () => {
             // Arrange

--- a/src/test/GameManager.timeLimit.test.ts
+++ b/src/test/GameManager.timeLimit.test.ts
@@ -153,7 +153,7 @@ describe('GameManager timeLimit integration', () => {
             expect(getGameStore().getTimeRemaining()).toBe(5);
 
             // Act: Reset game state
-            gameManager.resetGameState();
+            await gameManager.resetGameState();
 
             // Assert: timeRemaining should be reset to timeLimit
             expect(getGameStore().getTimeRemaining()).toBe(15);


### PR DESCRIPTION
## Summary
- Fixed moving platforms not resetting to initial positions on game restart
- Modified `GameManager.resetGameState()` to reload stage data for clean initial state
- Changed `resetGameState()` to async method to support stage reloading
- Updated all calls to `resetGameState()` to use await for proper async handling

## Technical Changes
- **GameManager.ts**: Added stage reloading in `resetGameState()` method
- **Game.ts**: Updated calls to `resetGameState()` to use await
- **GameManager.test.ts**: Added comprehensive test for moving platform reset functionality
- **GameManager.timeLimit.test.ts**: Updated test to use await for async resetGameState

## Test Coverage
Added new test case that:
1. Loads a stage with moving platforms
2. Simulates platform movement over time
3. Verifies platforms have moved from initial positions
4. Calls resetGameState() and confirms platforms return to initial positions
5. Uses deep copy for mock data to avoid object reference sharing issues

## Problem Solved
Previously, moving platforms would retain their current position when players restarted the game, making level difficulty inconsistent and unpredictable. Now platforms consistently return to their starting positions as defined in stage data.

## Test Plan
- [x] Unit tests pass for GameManager
- [x] Moving platform reset functionality works correctly
- [x] No regression in existing game behavior
- [x] TypeScript compilation succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)