### PR TITLE
fix: ensure death count UI updates immediately after player death

### DIFF
--- a/src/core/Game.ts
+++ b/src/core/Game.ts
@@ -116,6 +116,10 @@ export class JumpingDotGame {
         // Update timer UI if game is running
         if (this.gameState.gameRunning && !this.gameState.gameOver) {
             this.gameUI.updateTimer();
+        }
+
+        // Always update death count UI when game is running (including after death)
+        if (this.gameState.gameRunning) {
             this.gameUI.updateDeathCount();
         }
 


### PR DESCRIPTION
## Summary
Fixes Issue #127 where the death count display does not update immediately when the player dies.

## Problem
- Death count only updated when `\!gameState.gameOver` condition was true
- When player dies → `gameOver = true` → UI update stops
- Death count remained at previous value during Game Over screen

## Solution
- Move `updateDeathCount()` call outside the `\!gameOver` conditional
- Death count now updates in the same frame as death detection  
- Maintains existing update flow for other UI components

## Changes
- **Game.ts**: Separated death count updates from timer updates
- Death count UI now updates when `gameRunning` (includes post-death state)
- Timer UI still only updates when `gameRunning && \!gameOver`

## Test Plan
- [x] All existing tests pass (302/302)
- [x] No regressions in game functionality
- [x] Death count updates immediately upon player death
- [x] UI timing remains consistent for other components

## User Experience Impact
- ✅ Immediate visual feedback when death occurs
- ✅ Death count visible during Game Over menu
- ✅ No confusion about death registration
- ✅ Improved game polish and responsiveness

🤖 Generated with [Claude Code](https://claude.ai/code)